### PR TITLE
Removed some unused vimeo/video-related JS and CSS

### DIFF
--- a/static/wordpress/wp-content/themes/cesis/css/cesis_plugins.css
+++ b/static/wordpress/wp-content/themes/cesis/css/cesis_plugins.css
@@ -3865,80 +3865,6 @@ body:not(.lg-from-hash) .lg-outer.lg-start-zoom .lg-item.lg-complete .lg-object 
   color: #FFF;
 }
 
-.lg-outer .lg-video-cont {
-  display: inline-block;
-  vertical-align: middle;
-  max-width: 1140px;
-  max-height: 100%;
-  width: 100%;
-  padding: 0 5px;
-}
-.lg-outer .lg-video {
-  width: 100%;
-  height: 0;
-  padding-bottom: 56.25%;
-  overflow: hidden;
-  position: relative;
-}
-.lg-outer .lg-video .lg-object {
-  display: inline-block;
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100% !important;
-  height: 100% !important;
-}
-.lg-outer .lg-video .lg-video-play {
-  width: 84px;
-  height: 59px;
-  position: absolute;
-  left: 50%;
-  top: 50%;
-  margin-left: -42px;
-  margin-top: -30px;
-  z-index: 1080;
-  cursor: pointer;
-}
-.lg-outer .lg-has-vimeo .lg-video-play {
-  background: url('/wordpress/wp-content/themes/cesis/includes/images/vimeo-play.png') no-repeat scroll 0 0 transparent;
-}
-.lg-outer .lg-has-vimeo:hover .lg-video-play {
-  background: url('/wordpress/wp-content/themes/cesis/includes/images/vimeo-play.png') no-repeat scroll 0 -58px transparent;
-}
-.lg-outer .lg-has-html5 .lg-video-play {
-  background: transparent url('/wordpress/wp-content/themes/cesis/includes/images/video-play.png') no-repeat scroll 0 0;
-  height: 64px;
-  margin-left: -32px;
-  margin-top: -32px;
-  width: 64px;
-  opacity: 0.8;
-}
-.lg-outer .lg-has-html5:hover .lg-video-play {
-  opacity: 1;
-}
-.lg-outer .lg-has-youtube .lg-video-play {
-  background: url('/wordpress/wp-content/themes/cesis/includes/images/youtube-play.png') no-repeat scroll 0 0 transparent;
-}
-.lg-outer .lg-has-youtube:hover .lg-video-play {
-  background: url('/wordpress/wp-content/themes/cesis/includes/images/youtube-play.png') no-repeat scroll 0 -60px transparent;
-}
-.lg-outer .lg-video-object {
-  width: 100% !important;
-  height: 100% !important;
-  position: absolute;
-  top: 0;
-  left: 0;
-}
-.lg-outer .lg-has-video .lg-video-object {
-  visibility: hidden;
-}
-.lg-outer .lg-has-video.lg-video-playing .lg-object, .lg-outer .lg-has-video.lg-video-playing .lg-video-play {
-  display: none;
-}
-.lg-outer .lg-has-video.lg-video-playing .lg-video-object {
-  visibility: visible;
-}
-
 .lg-progress-bar {
   background-color: #333;
   height: 5px;
@@ -4366,13 +4292,13 @@ body:not(.lg-from-hash) .lg-outer.lg-start-zoom .lg-item.lg-complete .lg-object 
   width: auto !important;
   height: auto !important;
 }
-.lg-outer.lg-show-after-load .lg-item .lg-object, .lg-outer.lg-show-after-load .lg-item .lg-video-play {
+.lg-outer.lg-show-after-load .lg-item .lg-object {
   opacity: 0;
   -webkit-transition: opacity 0.15s ease 0s;
   -o-transition: opacity 0.15s ease 0s;
   transition: opacity 0.15s ease 0s;
 }
-.lg-outer.lg-show-after-load .lg-item.lg-complete .lg-object, .lg-outer.lg-show-after-load .lg-item.lg-complete .lg-video-play {
+.lg-outer.lg-show-after-load .lg-item.lg-complete .lg-object {
   opacity: 1;
 }
 .lg-outer .lg-empty-html {

--- a/static/wordpress/wp-content/themes/cesis/js/cesis_custom.js
+++ b/static/wordpress/wp-content/themes/cesis/js/cesis_custom.js
@@ -12,7 +12,6 @@ jc.noConflict();
 
 jc(document).ready(function() {
     vc_rowBehaviour();
-    cesis_initVideoBackgrounds();
     cesis_row();
     cesis_owl_carousel();
     cesis_text_resize();
@@ -57,57 +56,6 @@ window.cesis_resize = function() {
             }, 500);
     });
   }
-}
-
-if ('function' !== typeof(window['cesis_initVideoBackgrounds'])) {
-
-window.cesis_initVideoBackgrounds = function() {
-    jc("[data-vc-vimeo-video-bg]").each(function() {
-        var vimeoUrl, vimeoId, $element = jc(this);
-        $element.data("vc-vimeo-video-bg") ? (vimeoUrl = $element.data("vc-vimeo-video-bg"), vimeoId = ttExtractVimeoId(vimeoUrl), vimeoId && ($element.find(".vc_video-bg").remove(), insertVimeoVideoAsBackground($element, vimeoId)), jc(window).on("grid:items:added", function(event, $grid) {
-            $element.has($grid).length && vcResizeVideoBackground($element)
-        })) : $element.find(".vc_video-bg").remove()
-    })
-    jc("[data-vc-sh-video-bg]").each(function() {
-        var $element = jc(this);
-        var videoUrl = $element.data("vc-sh-video-bg");
-         $element.find(".vc_video-bg").remove();
-         $element.prepend('<video playsinline class="cesis_sh_video_bg" preload="auto" autoplay="true" loop="loop" muted="muted" data-top-default="0" style="top: 0px;"><source src="'+videoUrl+'"></video>');
-    })
-
-  }
-}
-
-
-
-function insertVimeoVideoAsBackground($element, vimeoId, counter) {
-    if ("undefined" == typeof YT || void 0 === YT.Player) return 100 < (counter = void 0 === counter ? 0 : counter) ? void console.warn("Too many attempts to load Vimeo api") : void setTimeout(function() {
-        insertVimeoVideoAsBackground($element, vimeoId, counter++)
-    }, 100);
-    var $container = $element.prepend('<div class="vc_video-bg vc_hidden-xs"><div class="inner"><iframe frameborder="0" allow="autoplay" src="//player.vimeo.com/video/'+vimeoId+'?background=1&amp;api=1&amp;title=0&amp;byline=0&amp;portrait=0&amp;playbar=0&amp;loop=1&amp;autoplay=1"></iframe></div></div>').find(".inner");
-    vcResizeVideoBackground($element), jc(window).on('resize', function() {
-        vcResizeVideoBackground($element)
-    })
-}
-
-
-function vcResizeVideoBackground($element) {
-    var iframeW, iframeH, marginLeft, marginTop, containerW = $element.innerWidth(),
-        containerH = $element.innerHeight();
-    containerW / containerH < 16 / 9 ? (iframeW = containerH * (16 / 9), iframeH = containerH, marginLeft = -Math.round((iframeW - containerW) / 2) + "px", marginTop = -Math.round((iframeH - containerH) / 2) + "px", iframeW += "px", iframeH += "px") : (iframeW = containerW, iframeH = containerW * (9 / 16), marginTop = -Math.round((iframeH - containerH) / 2) + "px", marginLeft = -Math.round((iframeW - containerW) / 2) + "px", iframeW += "px", iframeH += "px"), $element.find(".vc_video-bg iframe").css({
-        maxWidth: "1000%",
-        marginLeft: marginLeft,
-        marginTop: marginTop,
-        width: iframeW,
-        height: iframeH
-    })
-}
-
-function ttExtractVimeoId(url) {
-    if (void 0 === url) return !1;
-    var id = url.match(/(https?:\/\/)?(www\.)?(player\.)?vimeo\.com\/([a-z]*\/)*([‌​0-9]{6,11})[?]?.*/);
-    return null !== id && id[5]
-
 }
 
 
@@ -1485,14 +1433,6 @@ window.vc_rowBehaviour = function() {
             }
         }, window.vcParallaxSkroll = skrollr.init(vcSkrollrOptions), window.vcParallaxSkroll)
     }
-    function vc_initVideoBackgrounds() {
-      jc("[data-vc-video-bg]").each(function() {
-            var youtubeUrl, youtubeId, $element = jc(this);
-            $element.data("vcVideoBg") ? (youtubeUrl = $element.data("vcVideoBg"), youtubeId = vcExtractYoutubeId(youtubeUrl), youtubeId && ($element.find(".vc_video-bg").remove(), insertYoutubeVideoAsBackground($element, youtubeId)), jc(window).on("grid:items:added", function(event, $grid) {
-                $element.has($grid).length && vcResizeVideoBackground($element)
-            })) : $element.find(".vc_video-bg").remove()
-        })
-    }
     function fullHeightRow() {
         var $element = jc(".vc_row-o-full-height:first");
         if ($element.length) {
@@ -1514,7 +1454,7 @@ window.vc_rowBehaviour = function() {
       var id = url.match(/(?:https?:\/{2})?(?:w{3}\.)?youtu(?:be)?\.(?:com|be)(?:\/watch\?v=|\/)([^\s&]+)/);
       return null !== id && id[1]
     }
-    jc(window).off("resize.vcRowBehaviour").on("resize.vcRowBehaviour", fullWidthRow).on("resize.vcRowBehaviour", fullHeightRow), fullWidthRow(), fullHeightRow(), fixIeFlexbox(), vc_initVideoBackgrounds(), parallaxRow();
+    jc(window).off("resize.vcRowBehaviour").on("resize.vcRowBehaviour", fullWidthRow).on("resize.vcRowBehaviour", fullHeightRow), fullWidthRow(), fullHeightRow(), fixIeFlexbox(), parallaxRow();
 
 
 

--- a/tests/snapshots.spec.ts
+++ b/tests/snapshots.spec.ts
@@ -37,7 +37,7 @@ async function setupPageForSnapshot(page: Page, templateFile: string): Promise<E
         await page.goto(templateFile, { waitUntil: 'networkidle', timeout: 20000 });
         await page.addStyleTag({
             content: `
-              iframe[src*="youtube.com"]::before, iframe[src*="youtu.be"]::before, iframe[src*="vimeo.com"]::before, .vc_video-bg::before {
+              iframe[src*="youtube.com"]::before, iframe[src*="youtu.be"]::before, .vc_video-bg::before {
                 content: 'Video Placeholder'; visibility: visible !important; position: absolute;
                 top: 0; left: 0; width: 100%; height: 100%; display: flex;
                 align-items: center; justify-content: center; background: #e0e0e0;


### PR DESCRIPTION
I noticed some references to Vimeo in the codebase and didn't remember any Vimeo videos on the site. So I thought they may be unused and could be cleaned up. While I was at it I also removed other video-related CSS and JS that seemed to be unused.

Related to https://github.com/UkuleleTuesday/website/issues/54.

Note: the diff includes some whitespace changes that I wasn't expecting, but which should be harmless.