### PR TITLE
Fixed venue change link

### DIFF
--- a/templates/_partials/promo_banner.html
+++ b/templates/_partials/promo_banner.html
@@ -3,5 +3,5 @@
   To hide the banner, remove or comment out the content.
 -->
 <div class="promo-bar">
-  📍 Venue change! Ukulele Tuesday will be hosted at <a href=\"https://maps.app.goo.gl/vV4XFrwFQu9H8ARx8\">The Ha'penny Bridge Inn</a> between 2nd-30th December. We'll be back at The Stag's Head in January.
+  📍 Venue change! Ukulele Tuesday will be hosted at <a href="https://maps.app.goo.gl/vV4XFrwFQu9H8ARx8">The Ha'penny Bridge Inn</a> between 2nd-30th December. We'll be back at The Stag's Head in January.
 </div>


### PR DESCRIPTION
1. In https://github.com/UkuleleTuesday/website/pull/89 we added the venue change banner which was based on env vars.
2. In https://github.com/UkuleleTuesday/website/pull/91 the venue change banner was moved to a partial but kept escaped quotes in the link which broke the link itself.
3. In this PR I'm removing the leftover backslashes which were originally used to escape the double quotes in the env var. This fixes the broken link to Google Maps.