### PR TITLE
Changed Tuesday end time to 22:30

### DIFF
--- a/templates/_partials/footer.html
+++ b/templates/_partials/footer.html
@@ -16,7 +16,7 @@
           <section class="cesis_f_widget widget_text" id="text-3">
             <h2 class="cesis_f_widget_title">The Jam Session</h2>
             <div class="textwidget">
-              <p>Tuesdays from 20:00 to 23:00</p>
+              <p>Tuesdays from 20:00 to 22:30</p>
               <p>
                 Address: <strong><a href="https://www.google.com/maps/dir//The+Stags+Head+1+Dame+Ct+Dublin+D02+TW84/@53.3438235,-6.2636593,16z/data=!4m8!4m7!1m0!1m5!1m1!1s0x48670e9ce8919bf1:0x7310209e5b553be6!2m2!1d-6.2636593!2d53.3438235"
    rel="noopener"


### PR DESCRIPTION
The website footer said that the Tuesday sessions run between 20:00 to 23:00, when in fact they end at 22:30. I've updated that.