### PR TITLE
Removed calendar legend

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -214,37 +214,6 @@
                 data-min_size="18"
                 id="upcoming-events">Upcoming Events</h2>
             <p>See what’s coming up — Tuesday jams, gigs, and festival shows.</p>
-            <div class="calendar-legend"
-                 style="margin-bottom: 10px;
-                        display: flex;
-                        align-items: center;
-                        gap: 20px;
-                        flex-wrap: wrap">
-              <div class="calendar-legend-item"
-                   style="display: flex;
-                          align-items: center;
-                          gap: 5px">
-                <span class="legend-color legend-color-jam-sessions"
-                      style="height: 15px;
-                             width: 15px;
-                             background-color: #f6bf26;
-                             border-radius: 3px;
-                             display: inline-block"></span>
-                <span>Jam Sessions</span>
-              </div>
-              <div class="calendar-legend-item"
-                   style="display: flex;
-                          align-items: center;
-                          gap: 5px">
-                <span class="legend-color legend-color-concerts"
-                      style="height: 15px;
-                             width: 15px;
-                             background-color: #0b8043;
-                             border-radius: 3px;
-                             display: inline-block"></span>
-                <span>Live Shows</span>
-              </div>
-            </div>
             <iframe src="https://calendar.google.com/calendar/embed?src=3a583720ada6b96add65d4dc75539408da8d79876140c012f4eb81b8b7fd1bb1%40group.calendar.google.com&ctz=Europe%2FDublin&mode=AGENDA"
                     style="border: 0"
                     width="100%"


### PR DESCRIPTION
### Related

* Closes https://github.com/UkuleleTuesday/website/issues/107

### Changes

Removed the calendar legend because we figured [the colours are not publicly visible](https://github.com/UkuleleTuesday/website/issues/107#issuecomment-3780716276).