### PR TITLE
Rename homepage "Read More" buttons to be descriptive

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -110,7 +110,7 @@
                                 border-radius:100px;
                                 background:#efa537;
                                 color:#ffffff"
-                         target="_self"><span class="btn-inner btn-icon-hover btn-icon-right"><span class="btn-text">Read More →</span></span></a>
+                         target="_self"><span class="btn-inner btn-icon-hover btn-icon-right"><span class="btn-text">Join the Session →</span></span></a>
                     </div>
                   </div>
                 </div>
@@ -192,7 +192,7 @@
                                 border-radius:100px;
                                 background:#efa537;
                                 color:#ffffff"
-                         target="_self"><span class="btn-inner btn-icon-hover btn-icon-right"><span class="btn-text">Read More →</span></span></a>
+                         target="_self"><span class="btn-inner btn-icon-hover btn-icon-right"><span class="btn-text">See Our Concerts →</span></span></a>
                     </div>
                   </div>
                 </div>


### PR DESCRIPTION
## Summary

Fixes #159.

The two "Read More →" buttons on the homepage didn't describe where they lead. They now have descriptive labels:

| Section | Destination | Old label | New label |
|---|---|---|---|
| Play Along With Us | `/tuesday-session/` | Read More → | **Join the Session →** |
| See Us Live | `/concerts/` | Read More → | **See Our Concerts →** |

Only the inner `<span class="btn-text">` text changed in `templates/index.html`; styling and links are unchanged.

## Verification

- `templates/index.html` no longer contains "Read More".
- Ran `python build.py` successfully; the rendered `public/index.html` shows the new labels and unchanged links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A99o4tAGcU3yhAAKtyyZvK

---
_Generated by [Claude Code](https://claude.ai/code/session_01A99o4tAGcU3yhAAKtyyZvK)_