### PR TITLE
Add banner: session moves to Wednesday 19th August

### DIFF
--- a/templates/_partials/promo_banner.html
+++ b/templates/_partials/promo_banner.html
@@ -2,8 +2,4 @@
   To display a promo banner, add HTML content below.
   To hide the banner, remove or comment out the content.
 -->
-<!--
-<div class="promo-bar">
-  
-</div>
--->
+<div class="promo-bar">📅 This week only: Ukulele Tuesday moves to Wednesday 19th August, same time and place.</div>


### PR DESCRIPTION
## What

Enables the site-wide promo banner to announce that this week's session is on **Wednesday 19th August** instead of Tuesday 18th, same time and venue.

> 📅 This week only: Ukulele Tuesday moves to Wednesday 19th August, same time and place.

## How

Single-file change to `templates/_partials/promo_banner.html` — uncomments the existing `.promo-bar` div, following the same pattern as the previous one-off announcements (St. Patrick's Day, December venue change, 30th Dec cancellation).

No CSS or layout changes needed: `.promo-bar` is already styled in `static/css/custom.css`, and `_layouts/base.html` already includes this partial above the header on every page.

## Verification

- `uvx pre-commit run --all-files` passes (djLint collapsed the div to one line — that reformat is included in the commit).
- `uv run python build.py` succeeds; the banner is present in every built page.
- Rendered locally and checked at 1280px and 390px: one line on desktop, wraps cleanly to two centered lines on mobile.
- ⚠️ Visual regression baselines need regenerating — **Actions → Visual Regression → mode `update`** on this branch.

## Follow-ups (outside this repo)

- The homepage upcoming-events list is driven by the "Ukulele Tuesday Public Events" Google Calendar — this week's event needs moving there too.
- Revert this PR after 19th August to take the banner down.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ud4jryHvhvNDmrpEsvv3Sa)_